### PR TITLE
Fix doubled logging

### DIFF
--- a/python/importer/main.py
+++ b/python/importer/main.py
@@ -48,6 +48,7 @@ def main(importer: func.TimerRequest, context: func.Context):
                 if is_importer_locked:
                     logger.error("Importer is LOCKED which means that importer should be already running. You can get"
                                 "rid of the lock by restarting the database if needed.")
+                    custom_db_log_handler.remove_handlers()
                     return
 
                 logger.info("Going to run importer.")


### PR DESCRIPTION
Logging handlers were not removed when imported is locked.

Some logs might still get doubled, when there are both analyzer and importer running at the same time, but hopefully they won't cumulate any more.

Closes #52 