### PR TITLE
Env refactoring (enables possibility to add new hfp events)

### DIFF
--- a/Dockerfile.api_deploy
+++ b/Dockerfile.api_deploy
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 
+# Workaround for obsolete jessie references (https://github.com/Azure/azure-functions-docker/issues/874)
+# Can be removed after fixed in base image.
+RUN sed -i '/jessie/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
 
 ENV TZ="Europe/Helsinki"

--- a/Dockerfile.importer_deploy
+++ b/Dockerfile.importer_deploy
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 
+# Workaround for obsolete jessie references (https://github.com/Azure/azure-functions-docker/issues/874)
+# Can be removed after fixed in base image.
+RUN sed -i '/jessie/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
 
 ENV TZ="Europe/Helsinki"

--- a/python/Dockerfile.api_local
+++ b/python/Dockerfile.api_local
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 
+# Workaround for obsolete jessie references (https://github.com/Azure/azure-functions-docker/issues/874)
+# Can be removed after fixed in base image.
+RUN sed -i '/jessie/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot

--- a/python/Dockerfile.importer_local
+++ b/python/Dockerfile.importer_local
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 
+# Workaround for obsolete jessie references (https://github.com/Azure/azure-functions-docker/issues/874)
+# Can be removed after fixed in base image.
+RUN sed -i '/jessie/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y libpq5 && rm -rf /var/lib/apt/lists/*
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot

--- a/python/analyzer/remove_old_data.py
+++ b/python/analyzer/remove_old_data.py
@@ -1,15 +1,14 @@
 import psycopg2
 import logging
-from common.utils import get_conn_params
 import common.constants as constants
-
+from common.config import POSTGRES_CONNECTION_STRING
 
 logger = logging.getLogger('importer')
 
 
 def remove_old_data():
 
-    conn = psycopg2.connect(get_conn_params())
+    conn = psycopg2.connect(POSTGRES_CONNECTION_STRING)
     try:
         with conn:
             with conn.cursor() as cur:

--- a/python/analyzer/run_analysis.py
+++ b/python/analyzer/run_analysis.py
@@ -3,8 +3,23 @@
 import psycopg2
 import logging
 import time
-from common.utils import env_with_default, comma_separated_floats_to_list, comma_separated_integers_to_list, get_conn_params
 import common.constants as constants
+from common.config import (
+    POSTGRES_CONNECTION_STRING,
+    STOP_NEAR_LIMIT_M,
+    MIN_OBSERVATIONS_PER_STOP,
+    MAX_NULL_STOP_DIST_M,
+    RADIUS_PERCENTILES,
+    MIN_RADIUS_PERCENTILES_TO_SUM,
+    DEFAULT_MIN_RADIUS_M,
+    MANUAL_ACCEPTANCE_MIN_RADIUS_M,
+    LARGE_SCATTER_PERCENTILE,
+    LARGE_SCATTER_RADIUS_M,
+    LARGE_JORE_DIST_M,
+    STOP_GUESSED_PERCENTAGE,
+    TERMINAL_IDS
+)
+
 
 start_time = 0
 logger = logging.getLogger('importer')
@@ -17,24 +32,7 @@ def get_time():
 def run_analysis():
     global start_time
 
-    stop_near_limit_m = env_with_default('STOP_NEAR_LIMIT_M', 50.0)
-    min_observations_per_stop = env_with_default('MIN_OBSERVATIONS_PER_STOP', 10)
-    max_null_stop_dist_m = env_with_default('MAX_NULL_STOP_DIST_M', 100.0)
-    radius_percentiles_str = env_with_default('RADIUS_PERCENTILES', '0.5,0.75,0.9,0.95')
-    radius_percentiles = comma_separated_floats_to_list(radius_percentiles_str)
-
-    min_radius_percentiles_to_sum_str = env_with_default('MIN_RADIUS_PERCENTILES_TO_SUM', '0.5,0.95')
-    min_radius_percentiles_to_sum = comma_separated_floats_to_list(min_radius_percentiles_to_sum_str)
-    default_min_radius_m = env_with_default('DEFAULT_MIN_RADIUS_M', 20.0)
-    manual_acceptance_min_radius_m = env_with_default('MANUAL_ACCEPTANCE_MIN_RADIUS_M', 40.0)
-    large_scatter_percentile = env_with_default('LARGE_SCATTER_PERCENTILE', 0.9)
-    large_scatter_radius_m = env_with_default('LARGE_SCATTER_RADIUS_M', 10.0)
-    large_jore_dist_m = env_with_default('LARGE_JORE_DIST_M', 25.0)
-    stop_guessed_percentage = env_with_default('STOP_GUESSED_PERCENTAGE', 0.05)
-    terminal_ids_str = env_with_default('TERMINAL_IDS', '1000001,1000015,2000002,2000003,2000212,4000011')
-    terminal_ids = comma_separated_integers_to_list(terminal_ids_str)
-
-    conn = psycopg2.connect(get_conn_params())
+    conn = psycopg2.connect(POSTGRES_CONNECTION_STRING)
     try:
         with conn:
             with conn.cursor() as cur:
@@ -64,7 +62,7 @@ def run_analysis():
                 )
 
                 cur.execute('SELECT * FROM stopcorr.guess_missing_stop_ids(%s)',
-                            (stop_near_limit_m, ))
+                            (STOP_NEAR_LIMIT_M, ))
                 logger.info(f'{get_time()} {cur.fetchone()[0]} observations updated with guessed stop_id')
 
                 conn.commit()
@@ -88,7 +86,7 @@ def run_analysis():
                 logger.info(f'{get_time()} {cur.fetchone()[0]} rows deleted from "stop_median"')
 
                 cur.execute('SELECT * FROM stopcorr.calculate_medians(%s, %s)',
-                            (min_observations_per_stop, max_null_stop_dist_m))
+                            (MIN_OBSERVATIONS_PER_STOP, MAX_NULL_STOP_DIST_M))
                 logger.info(f'{get_time()} {cur.fetchone()[0]} rows inserted into "stop_median"')
 
                 conn.commit()
@@ -99,20 +97,20 @@ def run_analysis():
                 conn.commit()
 
                 cur.execute('SELECT * FROM stopcorr.calculate_percentile_radii(%s)',
-                            (radius_percentiles, ))
-                logger.info(f'{get_time()} {cur.fetchone()[0]} "percentile_radii" created using percentiles {radius_percentiles_str}')
+                            (RADIUS_PERCENTILES, ))
+                logger.info(f'{get_time()} {cur.fetchone()[0]} "percentile_radii" created using percentiles {RADIUS_PERCENTILES}')
 
                 conn.commit()
 
                 cur.execute('CALL stopcorr.classify_medians(%s, %s, %s, %s, %s, %s, %s, %s)',
-                            (min_radius_percentiles_to_sum,
-                             default_min_radius_m,
-                             manual_acceptance_min_radius_m,
-                             large_scatter_percentile,
-                             large_scatter_radius_m,
-                             large_jore_dist_m,
-                             stop_guessed_percentage,
-                             terminal_ids)
+                            (MIN_RADIUS_PERCENTILES_TO_SUM,
+                             DEFAULT_MIN_RADIUS_M,
+                             MANUAL_ACCEPTANCE_MIN_RADIUS_M,
+                             LARGE_SCATTER_PERCENTILE,
+                             LARGE_SCATTER_RADIUS_M,
+                             LARGE_JORE_DIST_M,
+                             STOP_GUESSED_PERCENTAGE,
+                             TERMINAL_IDS)
                             )
                 cur.execute('SELECT count(*) FROM stopcorr.stop_median WHERE result_class IS NOT NULL')
                 logger.info(f'{get_time()} {cur.fetchone()[0]} "stop_median" updated with "result_class", "recommended_min_radius_m" and "manual_acceptance_needed"')

--- a/python/api/digitransit_import.py
+++ b/python/api/digitransit_import.py
@@ -5,7 +5,7 @@ import requests
 import csv
 from datetime import date
 from psycopg2 import sql
-from common.utils import get_conn_params
+from common.config import POSTGRES_CONNECTION_STRING
 
 GRAPHQL_URL = 'https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql'
 
@@ -106,7 +106,7 @@ def import_dataset(query_type, to_table, conn):
 def main():
     conn = None
     try:
-        with psycopg2.connect(get_conn_params()) as conn:
+        with psycopg2.connect(POSTGRES_CONNECTION_STRING) as conn:
             import_dataset(query_type='stations', to_table='jore.jore_station', conn=conn)
             import_dataset(query_type='stops', to_table='jore.jore_stop', conn=conn)
     finally:

--- a/python/api/hfp_import.py
+++ b/python/api/hfp_import.py
@@ -2,13 +2,13 @@
 
 import psycopg2
 from datetime import datetime
-from common.utils import get_conn_params
+from common.config import POSTGRES_CONNECTION_STRING
 
 def main():
     starttime = datetime.now()
     print(f'[{starttime}] Importing HFP events to database')
 
-    conn = psycopg2.connect(get_conn_params())
+    conn = psycopg2.connect(POSTGRES_CONNECTION_STRING)
     try:
         with conn:
             with conn.cursor() as cur:

--- a/python/api/make_report.py
+++ b/python/api/make_report.py
@@ -4,14 +4,11 @@ import pptx
 import psycopg2
 import os
 from datetime import date
-from common.utils import get_conn_params
-from common.utils import env_with_default
+from common.config import POSTGRES_CONNECTION_STRING, MIN_OBSERVATIONS_PER_STOP, LARGE_JORE_DIST_M
+
 
 def main():
-    min_observations_per_stop = env_with_default('MIN_OBSERVATIONS_PER_STOP', 100)
-    large_jore_dist_m = env_with_default('LARGE_JORE_DIST_M', 25.0)
-
-    conn = psycopg2.connect(get_conn_params())
+    conn = psycopg2.connect(POSTGRES_CONNECTION_STRING)
 
     try:
         with conn:
@@ -21,8 +18,8 @@ def main():
                              WHERE (sm.n_stop_known + sm.n_stop_guessed) >= %s\
                                AND sm.dist_to_jore_point_m >= %s\
                                 OR sm.dist_to_jore_point_m IS NULL',
-                            (min_observations_per_stop,
-                             large_jore_dist_m))
+                            (MIN_OBSERVATIONS_PER_STOP,
+                             LARGE_JORE_DIST_M))
                 colnames = [desc[0] for desc in cur.description]
                 res = [{col: row[idx] for idx, col in enumerate(colnames)} for row in cur.fetchall()]
     finally:

--- a/python/api/routers/stops.py
+++ b/python/api/routers/stops.py
@@ -4,7 +4,8 @@
 from fastapi import APIRouter, HTTPException
 import psycopg2 as psycopg
 
-from common.utils import get_conn_params, tuples_to_feature_collection
+from common.utils import tuples_to_feature_collection
+from common.config import POSTGRES_CONNECTION_STRING
 from api.digitransit_import import main as run_digitransit_import
 
 router = APIRouter(
@@ -26,7 +27,7 @@ async def run_import():
 @router.get("/jore_stops")
 async def get_jore_stops(stop_id = -1):
     """Returns a GeoJSON FeatureCollection of either all jore stops or one jore stop found with given stop_id"""
-    with psycopg.connect(get_conn_params()) as conn:
+    with psycopg.connect(POSTGRES_CONNECTION_STRING) as conn:
         with conn.cursor() as cur:
 
             cur.execute("SELECT * FROM api.view_jore_stop_4326")
@@ -58,7 +59,7 @@ async def get_stop_medians(stop_id = -1):
     """
     Returns a GeoJSON FeatureCollection of stop medians and their percentile radii
     """
-    with psycopg.connect(get_conn_params()) as conn:
+    with psycopg.connect(POSTGRES_CONNECTION_STRING) as conn:
         with conn.cursor() as cur:
 
             cur.execute("SELECT * FROM api.view_stop_median_4326")
@@ -92,7 +93,7 @@ async def get_hfp_points(stop_id: str):
     Returns a GeoJSON FeatureCollection with HFP (door) observations which were used for analysis of that stop_id
     OR which have NULL stop_id value but are located max search_distance_m (default 100) around the stop
     """
-    with psycopg.connect(get_conn_params()) as conn:
+    with psycopg.connect(POSTGRES_CONNECTION_STRING) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT * FROM api.view_observation_4326 \
                 WHERE st_asgeojson -> 'properties' ->> 'stop_id' = %(stop_id)s", {'stop_id': stop_id})
@@ -122,7 +123,7 @@ async def get_percentile_circles(stop_id: str):
     """
     Returns a GeoJSON FeatureCollection of percentile circles around the given stop by stop_id.
     """
-    with psycopg.connect(get_conn_params()) as conn:
+    with psycopg.connect(POSTGRES_CONNECTION_STRING) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT api.get_percentile_circles_with_stop_id(%(stop_id)s)", {'stop_id': stop_id })
             percentile_circles = cur.fetchall()

--- a/python/common/config.py
+++ b/python/common/config.py
@@ -16,6 +16,7 @@ How to use envs in the app:
 import os
 import logging
 from collections.abc import Callable
+from typing import Union
 
 
 def dummy(env: str) -> str:
@@ -43,12 +44,12 @@ def env_as_float_list(env: str) -> list[float]:
     return [float(item.strip()) for item in env.split(",")]
 
 
-def get_env(var_name: str, default_value: str = "", modifier: Callable = dummy):
+def get_env(var_name: str, default_value: Union[str, None] = None, modifier: Callable = dummy):
     """Function to read env and modify it with modifier function.
     Raises error if env is not available and default_value is not given."""
     env = os.getenv(var_name)
     if env is None:
-        if default_value:
+        if default_value is not None:
             env = default_value
             logging.warning(f"{var_name} not set in env, falling back to default value {default_value}")
         else:

--- a/python/common/config.py
+++ b/python/common/config.py
@@ -1,0 +1,87 @@
+"""
+Module to read values from env
+
+How to add new env:
+- Make sure new variable is defined as env variable
+- Add the env as a new variable and call get_env function
+- You can give default value for the env. If the env is required, leave the default field empty
+- Add modifier function if the env should be converted to another type, e.g. for str to int.
+
+How to use envs in the app:
+- import variable like
+`from common.config import MY_ENV`
+
+"""
+
+import os
+import logging
+from collections.abc import Callable
+
+
+def dummy(env: str) -> str:
+    """Dummy function to be called if env should be used as str"""
+    return env
+
+
+def env_as_int(env: str) -> int:
+    return int(env)
+
+
+def env_as_float(env: str) -> float:
+    return float(env)
+
+
+def env_as_upper_str_list(env: str) -> list[str]:
+    return [item.strip().upper() for item in env.split(",")]
+
+
+def env_as_int_list(env: str) -> list[int]:
+    return [int(item.strip()) for item in env.split(",")]
+
+
+def env_as_float_list(env: str) -> list[float]:
+    return [float(item.strip()) for item in env.split(",")]
+
+
+def get_env(var_name: str, default_value: str = "", modifier: Callable = dummy):
+    """Function to read env and modify it with modifier function.
+    Raises error if env is not available and default_value is not given."""
+    env = os.getenv(var_name)
+    if env is None:
+        if default_value:
+            env = default_value
+            logging.warning(f"{var_name} not set in env, falling back to default value {default_value}")
+        else:
+            raise ValueError(f"{var_name} is required, but was not found in env.")
+    return modifier(env)
+
+
+# Envs for connections to Posgtres and Azure
+HFP_STORAGE_CONTAINER_NAME: str = get_env("HFP_STORAGE_CONTAINER_NAME")
+HFP_STORAGE_CONNECTION_STRING: str = get_env("HFP_STORAGE_CONNECTION_STRING")
+POSTGRES_CONNECTION_STRING: str = get_env("POSTGRES_CONNECTION_STRING")
+
+# Envs related to importing blob
+HFP_EVENTS_TO_IMPORT: list[str] = get_env("HFP_EVENTS_TO_IMPORT", modifier=env_as_upper_str_list)
+IMPORT_COVERAGE_DAYS: int = get_env("IMPORT_COVERAGE_DAYS", "14", modifier=env_as_int)
+
+# Authentication str for docs.
+DEFAULT_AUTH_CODE: str = get_env("DEFAULT_AUTH_CODE", "")
+
+# Envs for stop analysis
+STOP_NEAR_LIMIT_M: float = get_env("STOP_NEAR_LIMIT", "25.0", modifier=env_as_float)
+MIN_OBSERVATIONS_PER_STOP: int = get_env("MIN_OBSERVATIONS_PER_STOP", "100", modifier=env_as_int)
+MAX_NULL_STOP_DIST_M: float = get_env("MAX_NULL_STOP_DIST_M", "100.0", modifier=env_as_float)
+RADIUS_PERCENTILES: list[float] = get_env("RADIUS_PERCENTILES", "0.5,0.75,0.9,0.95", modifier=env_as_float_list)
+MIN_RADIUS_PERCENTILES_TO_SUM: list[float] = get_env(
+    "MIN_RADIUS_PERCENTILES_TO_SUM", "0.5,0.95", modifier=env_as_float_list
+)
+DEFAULT_MIN_RADIUS_M: float = get_env("DEFAULT_MIN_RADIUS_M", "20.0", modifier=env_as_float)
+MANUAL_ACCEPTANCE_MIN_RADIUS_M: float = get_env("MANUAL_ACCEPTANCE_MIN_RADIUS_M", "40.0", modifier=env_as_float)
+LARGE_SCATTER_PERCENTILE: float = get_env("LARGE_SCATTER_PERCENTILE", "0.9", modifier=env_as_float)
+LARGE_SCATTER_RADIUS_M: float = get_env("LARGE_SCATTER_RADIUS_M", "10.0", modifier=env_as_float)
+LARGE_JORE_DIST_M: float = get_env("LARGE_JORE_DIST_M", "25.0", modifier=env_as_float)
+STOP_GUESSED_PERCENTAGE: float = get_env("STOP_GUESSED_PERCENTAGE", "0.05", modifier=env_as_float)
+TERMINAL_IDS: list[int] = get_env(
+    "TERMINAL_IDS", "1000001,1000015,2000002,2000003,2000212,4000011", modifier=env_as_int_list
+)

--- a/python/common/config.py
+++ b/python/common/config.py
@@ -69,8 +69,8 @@ IMPORT_COVERAGE_DAYS: int = get_env("IMPORT_COVERAGE_DAYS", "14", modifier=env_a
 DEFAULT_AUTH_CODE: str = get_env("DEFAULT_AUTH_CODE", "")
 
 # Envs for stop analysis
-STOP_NEAR_LIMIT_M: float = get_env("STOP_NEAR_LIMIT", "25.0", modifier=env_as_float)
-MIN_OBSERVATIONS_PER_STOP: int = get_env("MIN_OBSERVATIONS_PER_STOP", "100", modifier=env_as_int)
+STOP_NEAR_LIMIT_M: float = get_env("STOP_NEAR_LIMIT_M", "50.0", modifier=env_as_float)
+MIN_OBSERVATIONS_PER_STOP: int = get_env("MIN_OBSERVATIONS_PER_STOP", "10", modifier=env_as_int)
 MAX_NULL_STOP_DIST_M: float = get_env("MAX_NULL_STOP_DIST_M", "100.0", modifier=env_as_float)
 RADIUS_PERCENTILES: list[float] = get_env("RADIUS_PERCENTILES", "0.5,0.75,0.9,0.95", modifier=env_as_float_list)
 MIN_RADIUS_PERCENTILES_TO_SUM: list[float] = get_env(

--- a/python/common/database.py
+++ b/python/common/database.py
@@ -1,4 +1,4 @@
 from psycopg_pool import AsyncConnectionPool
-from common.utils import get_conn_params
+from common.config import POSTGRES_CONNECTION_STRING
 
-pool = AsyncConnectionPool(get_conn_params(), max_size=20)
+pool = AsyncConnectionPool(POSTGRES_CONNECTION_STRING, max_size=20)

--- a/python/common/logger_util.py
+++ b/python/common/logger_util.py
@@ -1,7 +1,7 @@
 import logging
 import psycopg2
 from psycopg2 import sql
-from common.utils import get_conn_params
+from common.config import POSTGRES_CONNECTION_STRING
 
 
 class PostgresDBHandler(logging.Handler):
@@ -17,7 +17,7 @@ class PostgresDBHandler(logging.Handler):
     def __init__(self, function_name: str):
         super().__init__()
         try:
-            self.sql_conn = psycopg2.connect(get_conn_params())
+            self.sql_conn = psycopg2.connect(POSTGRES_CONNECTION_STRING)
             self.sql_cursor = self.sql_conn.cursor()
         except psycopg2.OperationalError as err:
             self.sql_conn, self.sql_cursor = None, None

--- a/python/common/utils.py
+++ b/python/common/utils.py
@@ -1,18 +1,6 @@
-import os
 import pptx
 import logging as logger
 
-
-def get_conn_params() -> str:
-    return os.getenv("POSTGRES_CONNECTION_STRING", "")
-
-
-def env_with_default(var_name, default_value):
-    res = os.getenv(var_name)
-    if res is None:
-        res = default_value
-        print(f'{var_name} not set, falling back to default value {default_value}')
-    return res
 
 def tuples_to_feature_collection(geom_tuples: list[tuple]) -> dict:
     """Transforms GeoJSON tuples returned by psycopg into a FeatureCollection dict for REST API."""
@@ -22,17 +10,6 @@ def tuples_to_feature_collection(geom_tuples: list[tuple]) -> dict:
         "features": features
     }
 
-def comma_separated_floats_to_list(val_str):
-    res = val_str.split(',')
-    res = [x.strip() for x in res]
-    res = [float(x) for x in res]
-    return res
-
-def comma_separated_integers_to_list(val_str):
-    res = val_str.split(',')
-    res = [x.strip() for x in res]
-    res = [int(x) for x in res]
-    return res
 
 # From https://pbpython.com/creating-powerpoint.html
 def analyze_pptx(input_pptx, output_pptx):

--- a/python/importer/main.py
+++ b/python/importer/main.py
@@ -2,47 +2,35 @@
 import azure.functions as func
 from azure.storage.blob import ContainerClient
 from io import StringIO
-import os
 import csv
 import logging
 import zstandard
+import time
 from datetime import datetime, timedelta
 import psycopg2 as psycopg
 from common.logger_util import CustomDbLogHandler
-from common.utils import get_conn_params
 import common.constants as constants
-import time
-from typing import List
+from common.config import (
+    HFP_STORAGE_CONTAINER_NAME,
+    HFP_STORAGE_CONNECTION_STRING,
+    POSTGRES_CONNECTION_STRING,
+    HFP_EVENTS_TO_IMPORT,
+    IMPORT_COVERAGE_DAYS,
+)
 
 
 logger = logging.getLogger('importer')
 
 
-def get_event_types_to_import() -> List[str]:
-    """ Helper function to read hfp event types from env """
-    event_type_string = os.getenv("HFP_EVENTS_TO_IMPORT")
-    if not event_type_string:
-        logger.error("HFP_EVENTS_TO_IMPORT not defined. Nothing will be imported!")
-        return []
-
-    # Split to list, remove spaces and convert UPPERCASE
-    event_types = [e.strip().upper() for e in event_type_string.split(",")]
-    return event_types
-
-
 def get_azure_container_client() -> ContainerClient:
-    hfp_storage_container_name = os.getenv('HFP_STORAGE_CONTAINER_NAME', '')
-    if not hfp_storage_container_name:
-        logger.error("HFP_STORAGE_CONTAINER_NAME env not found, have you defined it?")
-    hfp_storage_connection_string = os.getenv('HFP_STORAGE_CONNECTION_STRING', '')
-    if not hfp_storage_connection_string:
-        logger.error("HFP_STORAGE_CONNECTION_STRING env not found, have you defined it?")
-    return ContainerClient.from_connection_string(conn_str=hfp_storage_connection_string, container_name=hfp_storage_container_name)
+    return ContainerClient.from_connection_string(
+        conn_str=HFP_STORAGE_CONNECTION_STRING, container_name=HFP_STORAGE_CONTAINER_NAME
+    )
 
 
 def start_import():
     global is_importer_locked
-    conn = psycopg.connect(get_conn_params())
+    conn = psycopg.connect(POSTGRES_CONNECTION_STRING)
 
     # Create a lock for import
     try:
@@ -65,7 +53,7 @@ def start_import():
         logger.error(f'Error when creating locks for importer: {e}')
 
     try:
-        import_day_data_from_past(os.getenv("IMPORT_COVERAGE_DAYS", 14))
+        import_day_data_from_past(IMPORT_COVERAGE_DAYS)
 
     except Exception as e:
         logger.error(f'Error when running importer: {e}')
@@ -102,7 +90,7 @@ def import_data(import_date):
 
     blob_names = []
 
-    conn = psycopg.connect(get_conn_params())
+    conn = psycopg.connect(POSTGRES_CONNECTION_STRING)
     with conn:
         with conn.cursor() as cur:
             for i, name in enumerate(storage_blob_names):
@@ -118,7 +106,7 @@ def import_data(import_date):
 
                 event_type = tags.get('eventType')
 
-                covered_by_import = event_type in get_event_types_to_import()
+                covered_by_import = event_type in HFP_EVENTS_TO_IMPORT
 
 
                 cur.execute("INSERT INTO importer.blob(name, type, min_oday, max_oday, min_tst, max_tst, row_count, covered_by_import) VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
@@ -150,7 +138,7 @@ def import_data(import_date):
 
 def import_blob(blob_name):
     # TODO: Use connection pooling
-    connection = psycopg.connect(get_conn_params())
+    connection = psycopg.connect(POSTGRES_CONNECTION_STRING)
     cur = connection.cursor()
     logger.debug(f"Processing blob: {blob_name}")
     blob_start_time = time.time()


### PR DESCRIPTION
- All env variables are now read in common/config.py
- HFP event types to be imported are now parametrized and should be set up via env in `HFP_EVENTS_TO_IMPORT`
- import coverage can be also configured via env in `IMPORT_COVERAGE_DAYS`. Default is 14 days.


To start the importer successfully, add for example the following row to .env:
```
HFP_EVENTS_TO_IMPORT=VP,DOO,DOC
```